### PR TITLE
Added link to divers needed by Cleanflight for Mac

### DIFF
--- a/book/opmanual_sky/10-build/35-phase3_device_configuration.md
+++ b/book/opmanual_sky/10-build/35-phase3_device_configuration.md
@@ -38,6 +38,8 @@ Before the FC can be configured, it must first be flashed with firmware. **Firmw
     - A workstation (or personal computer)
     - Flight controller (by this phase, it should be attached to drone)
     - USB to micro USB cable (by this phase, it should be connected to FC)
+    
+   NOTE: If using Mac OS X [this driver](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers) needs to be installed for Cleanflight to communicate with the flight controller.
 
 2. On a workstation, install and open [Cleanflight](http://cleanflight.com/).
 


### PR DESCRIPTION
I was not able to connect on my mac using cleanflight installing this driver solved the issue. 
I saw the problem again when helping someone else setup their drone, again this drive solved the issue.
Before we got a "no response from the bootloader programming failed" error when trying to flash.